### PR TITLE
SKALE-3876 added delay before deploy S-Chain part of IMA

### DIFF
--- a/inner_run.sh
+++ b/inner_run.sh
@@ -82,6 +82,7 @@ fi
 if [ ! -f /data_dir/all_ima_deploy_sc.txt ]; then
     echo " "
     echo "Will deploy IMA to S-Chain..."
+    sleep 20
     touch /data_dir/all_ima_deploy_sc.txt
     cd /dev_dir/IMA/proxy || exit
     #truffle compile &>> /data_dir/all_ima_deploy_sc.txt


### PR DESCRIPTION
SKALE IMA SDK cannot deploy S-Chain part of IMA successfully dew to long time of skaed initalization. I,e, truffle deployment is started earlier than skaled is ready to handle JSON RPC requests